### PR TITLE
Token.Claims ( Fixes "type jwt.Claims does not support indexing")

### DIFF
--- a/try.go
+++ b/try.go
@@ -94,7 +94,8 @@ func LoadUserFromToken(myToken string) (*User, error) {
 	//	fmt.Println("TOKEN", token, err)
 	//	return nil, errors.New("Token Parsing Problem")
 	//}
-	if _,err := bucket.Get(token.Claims["user"].(string),&u); err != nil{
+         // updated token.Claims["user"]  to token.Claims.(jwt.MapClaims)["user"] as per Migration of jwt 2.0 - jwt3.0 
+	if _,err := bucket.Get(token.Claims.(jwt.MapClaims)["user"].(string),&u); err != nil{
 		return nil, errors.New("User Loading Error")
 	}
 	return &u, nil
@@ -109,7 +110,8 @@ func (u *User) Save() bool{
 
 func (u *UserIntermediary) CreateUser() bool{
 	token := jwt.New(jwt.SigningMethodHS256)
-	token.Claims["user"] = u.User
+	// updated token.Claims["user"]  to token.Claims.(jwt.MapClaims) ["user"] as per Migration of jwt 2.0 - jwt3.0 
+	token.Claims.(jwt.MapClaims)["user"] = u.User
 	if encryptedToken, err := token.SignedString([]byte(hashToken)); err != nil{
 		return false
 	} else {


### PR DESCRIPTION
It seems like the try.go needs an update as per jwt3.0 

[https://github.com/dgrijalva/jwt-go/blob/master/MIGRATION_GUIDE.md ]
The old example for parsing a token looked like this..
    if token, err := jwt.Parse(tokenString, keyLookupFunc); err == nil {
        fmt.Printf("Token for user %v expires %v", token.Claims["user"], token.Claims["exp"])
    }
is now directly mapped to...
    if token, err := jwt.Parse(tokenString, keyLookupFunc); err == nil {
        claims := token.Claims.(jwt.MapClaims)
        fmt.Printf("Token for user %v expires %v", claims["user"], claims["exp"])
    }
